### PR TITLE
Add file and speed test properties

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,8 +73,10 @@ function clean (test) {
   return {
     title: test.title,
     fullTitle: test.fullTitle(),
+    file: test.file,
     duration: test.duration,
     currentRetry: test.currentRetry(),
+    speed: test.speed,
     err: cleanCycles(err)
   }
 }


### PR DESCRIPTION
This PR  adds `file` and `speed` properties on test object.
- `file` was added to `json` reporter in mocha `v7.2.0`
- `speed` was added to `json` reporter in mocha `v8.2.0`

I actually tested with even older version of mocha and looks like the properties are available there.

Backstory:
I'm adding mocha support to [test-reporter](https://github.com/dorny/test-reporter).
Thought it would be nice to have both the console spec reporter output and json report at same time. JSON report would be then processed by `test-reporter`. Found out it's possible only with `mocha-multi-reporters` and `json-file-reporter`. Unfortunately not having `file` property on test object is a blocker for me.
