### PR TITLE
Add file property on Test to output

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -73,6 +73,7 @@ function clean (test) {
   return {
     title: test.title,
     fullTitle: test.fullTitle(),
+    file: test.file,
     duration: test.duration,
     currentRetry: test.currentRetry(),
     err: cleanCycles(err)


### PR DESCRIPTION
This PR adds the optional 'file' property on Mocha.Test to the JSON output.